### PR TITLE
doc: fix htmx extension link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # json-enc-custom
-This is a custom extension for htmx, it takes the parameters from encodeParameters https://htmx.org/extensions/#defining, and parse the names of the forms like the examples below:
+This is a [custom extension](https://github.com/bigskysoftware/htmx-extensions/tree/main?tab=readme-ov-file#defining-an-extension) for htmx, it takes the parameters from encodeParameters, and parse the names of the forms like the examples below:
 ```html
 EXAMPLE 1: Basic Keys
 <form hx-ext='json-enc-custom'>


### PR DESCRIPTION
The extension is very nice to bind with https://github.com/bigskysoftware/htmx-extensions/blob/main/src/client-side-templates/README.md to implement HTML page based on HTMX for json based restapi application.

Fix README link as htmx 2.0 is out