### PR TITLE
Fix type-parsing when hx-post is not on a form node

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,21 @@
 
 <body>
     <!-- This is a form example -->
+    <h1>HX-POST in form</h1>
     <form id="test-form" hx-ext="json-enc-custom" hx-post="/" parse-types="true" style="display: flex; flex-direction: column;">
         <input name='index' type="number" value='15.7'>
         <input name='index' type="text" value='25'>
         <input name="index" type="range">
         <input name='index' type='checkbox'>
         <button type="submit">Enviar</button>
+    </form>
+
+    <h1>HX-POST in button</h1>
+    <form id="test-form" hx-ext="json-enc-custom" style="display: flex; flex-direction: column;">
+        <input name='index' type="number" value='15.7'>
+        <input name='index' type="text" value='25'>
+        <input name="index" type="range">
+        <input name='index' type='checkbox'>
+        <button type="submit" hx-post="/" parse-types="true">Enviar</button>
     </form>
 </body>

--- a/json-enc-custom.js
+++ b/json-enc-custom.js
@@ -5,7 +5,7 @@
             api = apiRef
         },
         /**
-         * Register a handler for all htmx events.
+         * Register a handler for all htmx events. Override the request Content-Type to `application/json` 
          * @param {string} name Event name
          * @param {Event|CustomEvent} evt Event object
          */
@@ -78,8 +78,7 @@
     function parseValues(elt, includedElt, name, value) {
         let match = `[name="${name}"]`;
 
-        let elements = elt.querySelectorAll(match);;
-
+        let elements = elt.closest('form').querySelectorAll(match); // find the closest owning form and use this as the root element for finding matches
 
         if (!elements.length && includedElt !== undefined) {
             // "hx-include" allows CSS query selectors which may return an specific node, e.g a single input

--- a/json-enc-custom.js
+++ b/json-enc-custom.js
@@ -4,11 +4,23 @@
         init: function (apiRef) {
             api = apiRef
         },
+        /**
+         * Register a handler for all htmx events.
+         * @param {string} name Event name
+         * @param {Event|CustomEvent} evt Event object
+         */
         onEvent: function (name, evt) {
             if (name === "htmx:configRequest") {
                 evt.detail.headers['Content-Type'] = "application/json";
             }
         },
+        /**
+         * Takes FormData specified by the user and returns an encoded string.
+         * @param {XMLHttpRequest} xhr Request object to send to the server
+         * @param {FormData} parameters Raw form data
+         * @param {Node} elt Node that owns the request
+         * @returns *|string|null
+         */
         encodeParameters: function (xhr, parameters, elt) {
             xhr.overrideMimeType('text/json');
 
@@ -20,6 +32,13 @@
         }
     });
 
+    /**
+     * Merge form data and hx-include data and encode to a JSON string. Apply type parsing if requested.
+     * @param {FormData} parameters Raw form data as provided by the user
+     * @param {Node} elt Node that owns the request
+     * @param {NodeList} includedElt Other elements that shall be considered for this request (hx-include)
+     * @returns *|string|null
+     */
     function encodingAlgorithm(parameters, elt, includedElt) {
         let resultingObject = Object.create(null);
         const PARAM_NAMES = Object.keys(parameters);
@@ -48,6 +67,14 @@
         return result
     }
 
+    /**
+     * Parse the value of one FormData parameter
+     * @param {Node} elt Node that owns the request
+     * @param {NodeList} includedElt Other elements that shall be considered for this request (hx-include)
+     * @param {string} name Parameter name
+     * @param {*} value Parameter value
+     * @returns Parsed values with correct types
+     */
     function parseValues(elt, includedElt, name, value) {
         let match = `[name="${name}"]`;
 
@@ -73,6 +100,12 @@
         return value;
     }
 
+    /**
+     * Parse value based on element type. Deals with special handling for checkbox, number, range, select-one, and select-multiple.
+     * @param {Node} elt Element owning the parameter
+     * @param {*} value Parameter value that shall be parsed
+     * @returns Parsed value with correct type
+     */
     function parseElementValue(elt, value) {
         if (elt) {
             if (elt.type === "checkbox") {
@@ -85,6 +118,11 @@
         return value;
     }
 
+    /**
+     * Parse the parameter name to assess the nesting level needed for construcing the JSON
+     * @param {string} name Parameter name
+     * @returns {Array} List of nesting instructions
+     */
     function JSONEncodingPath(name) {
         let path = name;
         let original = path;
@@ -136,6 +174,13 @@
         return steps;
     }
 
+    /**
+     * Construct the nested object according to the step instrtuctions
+     * @param {Object} context Container processed FormData parameters
+     * @param {Object} step Nesting instructions for the parameter
+     * @param {*} value Parameter value
+     * @returns 
+     */
     function setValueFromPath(context, step, value) {
         if (step.last) {
             context[step.key] = value;
@@ -171,6 +216,11 @@
         }
     }
 
+    /**
+     * Collect all nodes specified in `hx-include`
+     * @param {Node} elt Node owning the request
+     * @returns List of extra nodes with parameters to include in this request
+     */
     function getIncludedElement(elt) {
         let includedSelector = api.getClosestAttributeValue(elt, "hx-include");
 

--- a/json-enc-custom.js
+++ b/json-enc-custom.js
@@ -4,23 +4,11 @@
         init: function (apiRef) {
             api = apiRef
         },
-        /**
-         * Register a handler for all htmx events. Override the request Content-Type to `application/json` 
-         * @param {string} name Event name
-         * @param {Event|CustomEvent} evt Event object
-         */
         onEvent: function (name, evt) {
             if (name === "htmx:configRequest") {
                 evt.detail.headers['Content-Type'] = "application/json";
             }
         },
-        /**
-         * Takes FormData specified by the user and returns an encoded string.
-         * @param {XMLHttpRequest} xhr Request object to send to the server
-         * @param {FormData} parameters Raw form data
-         * @param {Node} elt Node that owns the request
-         * @returns *|string|null
-         */
         encodeParameters: function (xhr, parameters, elt) {
             xhr.overrideMimeType('text/json');
 
@@ -32,13 +20,6 @@
         }
     });
 
-    /**
-     * Merge form data and hx-include data and encode to a JSON string. Apply type parsing if requested.
-     * @param {FormData} parameters Raw form data as provided by the user
-     * @param {Node} elt Node that owns the request
-     * @param {NodeList} includedElt Other elements that shall be considered for this request (hx-include)
-     * @returns *|string|null
-     */
     function encodingAlgorithm(parameters, elt, includedElt) {
         let resultingObject = Object.create(null);
         const PARAM_NAMES = Object.keys(parameters);
@@ -67,14 +48,6 @@
         return result
     }
 
-    /**
-     * Parse the value of one FormData parameter
-     * @param {Node} elt Node that owns the request
-     * @param {NodeList} includedElt Other elements that shall be considered for this request (hx-include)
-     * @param {string} name Parameter name
-     * @param {*} value Parameter value
-     * @returns Parsed values with correct types
-     */
     function parseValues(elt, includedElt, name, value) {
         let match = `[name="${name}"]`;
 
@@ -99,12 +72,6 @@
         return value;
     }
 
-    /**
-     * Parse value based on element type. Deals with special handling for checkbox, number, range, select-one, and select-multiple.
-     * @param {Node} elt Element owning the parameter
-     * @param {*} value Parameter value that shall be parsed
-     * @returns Parsed value with correct type
-     */
     function parseElementValue(elt, value) {
         if (elt) {
             if (elt.type === "checkbox") {
@@ -117,11 +84,6 @@
         return value;
     }
 
-    /**
-     * Parse the parameter name to assess the nesting level needed for construcing the JSON
-     * @param {string} name Parameter name
-     * @returns {Array} List of nesting instructions
-     */
     function JSONEncodingPath(name) {
         let path = name;
         let original = path;
@@ -173,13 +135,6 @@
         return steps;
     }
 
-    /**
-     * Construct the nested object according to the step instrtuctions
-     * @param {Object} context Container processed FormData parameters
-     * @param {Object} step Nesting instructions for the parameter
-     * @param {*} value Parameter value
-     * @returns 
-     */
     function setValueFromPath(context, step, value) {
         if (step.last) {
             context[step.key] = value;
@@ -215,11 +170,6 @@
         }
     }
 
-    /**
-     * Collect all nodes specified in `hx-include`
-     * @param {Node} elt Node owning the request
-     * @returns List of extra nodes with parameters to include in this request
-     */
     function getIncludedElement(elt) {
         let includedSelector = api.getClosestAttributeValue(elt, "hx-include");
 

--- a/typedefs.js
+++ b/typedefs.js
@@ -1,0 +1,50 @@
+/**
+ * @typedef onEvent
+ * Register a handler for all htmx events. Override the request Content-Type to `application/json` 
+ * @param {string} name Event name
+ * @param {Event|CustomEvent} evt Event object
+ * 
+ * @typedef encodeParameters
+ * Takes FormData specified by the user and returns an encoded string.
+ * @param {XMLHttpRequest} xhr Request object to send to the server
+ * @param {FormData} parameters Raw form data
+ * @param {Node} elt Node that owns the request
+ * @returns *|string|null
+ * 
+ * @typedef encodingAlgorithm
+ * Merge form data and hx-include data and encode to a JSON string. Apply type parsing if requested.
+ * @param {FormData} parameters Raw form data as provided by the user
+ * @param {Node} elt Node that owns the request
+ * @param {NodeList} includedElt Other elements that shall be considered for this request (hx-include)
+ * @returns *|string|null
+ * 
+ * @typedef parseValues
+ * Parse the value of one FormData parameter
+ * @param {Node} elt Node that owns the request
+ * @param {NodeList} includedElt Other elements that shall be considered for this request (hx-include)
+ * @param {string} name Parameter name
+ * @param {*} value Parameter value
+ * @returns Parsed values with correct types
+ * 
+ * @typedef parseElementValue
+ * Parse value based on element type. Deals with special handling for checkbox, number, range, select-one, and select-multiple.
+ * @param {Node} elt Element owning the parameter
+ * @param {*} value Parameter value that shall be parsed
+ * @returns Parsed value with correct type
+ * 
+ * @typedef JSONEncodingPath
+ * Parse the parameter name to assess the nesting level needed for construcing the JSON
+ * @param {string} name Parameter name
+ * @returns {Array} List of nesting instructions
+ * 
+ * @typedef setValueFromPath
+ * Construct the nested object according to the step instrtuctions
+ * @param {Object} context Container processed FormData parameters
+ * @param {Object} step Nesting instructions for the parameter
+ * @param {*} value Parameter value
+ * 
+ * @typedef getIncludedElement
+ * Collect all nodes specified in `hx-include`
+ * @param {Node} elt Node owning the request
+ * @returns List of extra nodes with parameters to include in this request
+ */


### PR DESCRIPTION
Hi @Emtyloc , I managed to make a PR for https://github.com/Emtyloc/json-enc-custom/issues/13 after all.

Key change was in `parseValues()`: Instead of running the match against the owning element, it's now run against the closest `<form>` element. So, like htmx is collecting the parameter values without `hx-include`.

Bonus:
Added typed docstrings for all functions because it helped me understanding what the code does. Not sure if all descriptions and types are right though.