### PR TITLE
Fix #15: parsing types for select

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,19 +13,62 @@
     <!-- This is a form example -->
     <h1>HX-POST in form</h1>
     <form id="test-form" hx-ext="json-enc-custom" hx-post="/" parse-types="true" style="display: flex; flex-direction: column;">
-        <input name='index' type="number" value='15.7'>
-        <input name='index' type="text" value='25'>
+        <input name="index" type="number" value="15.7">
+        <input name="index" type="text" value="25">
         <input name="index" type="range">
-        <input name='index' type='checkbox'>
+        <input name="index" type="checkbox">
         <button type="submit">Enviar</button>
     </form>
 
     <h1>HX-POST in button</h1>
     <form id="test-form" hx-ext="json-enc-custom" style="display: flex; flex-direction: column;">
-        <input name='index' type="number" value='15.7'>
-        <input name='index' type="text" value='25'>
+        <input name="index" type="number" value="15.7">
+        <input name="index" type="text" value="25">
         <input name="index" type="range">
-        <input name='index' type='checkbox'>
+        <input name="index" type="checkbox">
         <button type="submit" hx-post="/" parse-types="true">Enviar</button>
+    </form>
+
+    <h1>All possible tags in form</h1> <!-- https://www.w3schools.com/tags/tag_form.asp -->
+    <form 
+        hx-ext="json-enc-custom" 
+        hx-post="/" 
+        parse-types="true"
+        style="display: flex; flex-direction: column;"
+    >
+        <fieldset style="display: flex; flex-direction: column;">
+            <input name="number" type="number" value="15.7">
+            <input name="text" type="text" value="25">
+            <input name="range" type="range">
+            <input name="checkbox" type="checkbox">
+            <input name="unknown">
+        </fieldset>
+        <textarea name="textarea">Example text</textarea>
+        <select name="select-one-combined">
+            <optgroup label="String options">
+                <option value="first">First</option>
+                <option value="second">Second</option>
+            </optgroup>
+            <optgroup label="Number options">
+                <option value="10">10</option>
+                <option value="3.14">3.14</option>
+            </optgroup>
+        </select>
+        <select name="select-one-numbers">
+            <option value="10">10</option>
+            <option value="3.14">3.14</option>
+        </select>
+        <select name="select-multiple-combined" multiple>
+            <option value="multiple-1">multiple-1</option>
+            <option value="multiple-2">multiple-2</option>
+            <option value="3">3</option>
+        </select>
+        <select name="select-multiple-numbers" multiple>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+        </select>
+
+        <button type="submit">Enviar</button>
     </form>
 </body>

--- a/json-enc-custom.js
+++ b/json-enc-custom.js
@@ -63,6 +63,23 @@
 
         if (!Array.isArray(value)) return parseElementValue(elements[0], value);
         
+        if (
+            elements.length === 1 &&
+            elements[0] instanceof HTMLSelectElement &&
+            elements[0].type === "select-multiple"
+        ) {
+            const elt = elements[0];
+            const convertToNumber = checkAllPossibleOptionsAreNumbers(elt);
+            for (let index = 0; index < value.length; index++) {
+                let arrayValue = value[index]
+                if (convertToNumber) {
+                    arrayValue = Number(arrayValue);
+                }
+                value[index] = parseElementValue(elt, arrayValue);
+            }
+            return value;
+        }
+
         for (let index = 0; index < value.length; index++) {
             let array_elt = elements[index];
             let array_value = value[index];
@@ -72,15 +89,36 @@
     }
 
     function parseElementValue(elt, value) {
-        if (elt) {
-            if (elt.type === "checkbox") {
+        switch (true) {
+        case elt instanceof HTMLInputElement:
+            switch (elt.type) {
+            case "checkbox":
                 return elt.checked;
-            }
-            if (elt.type === "number" || elt.type === "range" || elt.type === "select-one" || elt.type === "select-multiple") {
+            case "number":
+            case "range": 
                 return Number(value);
             }
-        }
+            break;
+        case elt instanceof HTMLSelectElement:
+            if (elt.type === "select-one" && checkAllPossibleOptionsAreNumbers(elt)) {
+                return Number(value);
+            }
+            break;
+        }        
         return value;
+    }
+
+    function checkAllPossibleOptionsAreNumbers(elt) {
+        const values = [...elt.options].map(o => o.value);
+        if (values.length == 0) {
+            return true;
+        }
+        for (const value of values) {
+            if (isNaN(Number(value))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     function JSONEncodingPath(name) {


### PR DESCRIPTION
Fixes #15 

There are two things I want to explain:

1.  The special case for `"select-multiple"` on line `66`. It's needed because the following loop on line `83` doesn't work for this case. This is because in a multiple select, there is only one element with many values. Perhaps it isn't ideal to put logic specific to multiple selects in that place, so I'm open to suggestions if you have any.

2.  Type picking for select tags. Because `<option>` elements don't have a `type` attribute, I had to come up with a strategy for converting values into numbers. The logic is: if all options' values are convertible to numbers (see the `checkAllPossibleOptionsAreNumbers` function), then every value is converted. If any of the values are not convertible, then none of the values are converted. Please let me know if this approach aligns with your vision for the `parse-types` feature.
