### PR TITLE
Fix some of the failing test cases

### DIFF
--- a/test.html
+++ b/test.html
@@ -478,6 +478,36 @@
                     "select-multiple-numbers":["1","2"]
                 }`
             },
+            21: {
+                desc: "select[multiple] with only one option selected",
+                form:
+                `
+                <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
+                    <select name="select" multiple> 
+                        <option value="1" selected>First</option>
+                        <option value="2">Second</option>
+                        <option value="3">Third</option>
+                    </select>
+                </form>
+                `,
+                expected: `{
+                    "select": ["1"]
+                }`
+            },
+            22: {
+                desc: "name is equal to \"values\"",
+                form:
+                `
+                <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
+                    <input type="text" name="values" value="abc"></input>
+                    <input type="text" name="value"  value="abc"></input>
+                </form>
+                `,
+                expected: `{
+                    "values": "abc",
+                    "value": "abc"
+                }`
+            },
         };
 
         const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
Hi! It's me again.
In the current implementation this form:
```html
<form>
    <select name="select" multiple>
        <option value="1" selected>First</option>
        <option value="2">Second</option>
    </select>
</form>
```
produces this `json`: 
```json
{"select": "1"}
``` 
But this form:
```html
<form>
    <select name="select" multiple>
        <option value="1" selected>First</option>
        <option value="2" selected>Second</option>
    </select>
</form>
```
produces this `json`:
```json
{"select": ["1", "2"]}
```
This behavior forces the backend to explicitly handle the case when only one option is selected, which I think is wrong. I believe the value of a select multiple element should always be an array. So the changes in this PR ensure that the value of a select multiple element is always an array.

I also fixed this test:
<img width="712" alt="image" src="https://github.com/user-attachments/assets/74b3f90a-4b77-4cf6-a6b7-b26244bdfe88" />
which required to add a case for empty square brackets - `[]` - to the `JSONEncodingPath` function.

But to keep the balance, I found a new failing test case :). For some reason, if the name of an element is `"values"`, its value does not appear in the resulting `json`. I believe it's due to some strange `JavaScript` peculiarity which I know nothing about, so I didn't try to fix it.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/69680103-2ead-4431-9c8f-33076ce7c0ee" />
