### PR TITLE
Add support for multipart/form-data

### DIFF
--- a/json-enc-custom.js
+++ b/json-enc-custom.js
@@ -1,24 +1,32 @@
 (function () {
     let api;
-    htmx.defineExtension('json-enc-custom', {
+    htmx.defineExtension("json-enc-custom", {
         init: function (apiRef) {
-            api = apiRef
+            api = apiRef;
         },
         onEvent: function (name, evt) {
             if (name === "htmx:configRequest") {
-                evt.detail.headers['Content-Type'] = "application/json";
+                let element = evt.detail.elt;
+                if (element.hasAttribute("hx-multipart")) {
+                    evt.detail.headers["Content-Type"] = "multipart/form-data";
+                } else {
+                    evt.detail.headers["Content-Type"] = "application/json";
+                }
             }
         },
         encodeParameters: function (xhr, parameters, elt) {
-            xhr.overrideMimeType('text/json');
+            if (!elt.hasAttribute("hx-multipart")) {
+                xhr.overrideMimeType("text/json");
+            }
 
             let encoded_parameters = encodingAlgorithm(parameters, elt);
 
             return encoded_parameters;
-        }
+        },
     });
 
     function encodingAlgorithm(parameters, elt, includedElt) {
+        let files = [];
         let resultingObject = Object.create(null);
         const PARAM_NAMES = Object.keys(parameters);
         const PARAM_VALUES = Object.values(parameters);
@@ -28,34 +36,52 @@
             let name = PARAM_NAMES[param_index];
             let value = PARAM_VALUES[param_index];
 
-            const elements = getChildrenByName(elt, name);
-            if (isSelectMultiple(elements) && !Array.isArray(value)) {
-                value = [value]; // force the value of select multiple to be an array
-            }
+            if (value instanceof File) {
+                files.push(value);
+            } else if (
+                Array.isArray(value) &&
+                Object.values(value).every((val) => val instanceof File)
+            ) {
+                files = Object.values(value);
+            } else {
+                const elements = getChildrenByName(elt, name);
+                if (isSelectMultiple(elements) && !Array.isArray(value)) {
+                    value = [value]; // force the value of select multiple to be an array
+                }
 
-            let parse_value = api.getAttributeValue(elt, "parse-types");
-            if (parse_value === "true" ) {
-                let includedElt = getIncludedElement(elt);
-                value = parseValues(elements, includedElt, value);
-            }
+                let parse_value = api.getAttributeValue(elt, "parse-types");
+                if (parse_value === "true") {
+                    let includedElt = getIncludedElement(elt);
+                    value = parseValues(elements, includedElt, value);
+                }
 
-            let steps = JSONEncodingPath(name);
-            let context = resultingObject;
+                let steps = JSONEncodingPath(name);
+                let context = resultingObject;
 
-            for (let step_index = 0; step_index < steps.length; step_index++) {
-                let step = steps[step_index];
-                context = setValueFromPath(context, step, value);
+                for (let step_index = 0; step_index < steps.length; step_index++) {
+                    let step = steps[step_index];
+                    context = setValueFromPath(context, step, value);
+                }
             }
         }
 
         let result = JSON.stringify(resultingObject);
-        return result
+        if (elt.hasAttribute("hx-multipart")) {
+            const formData = new FormData();
+            formData.append("data", result);
+            for (const file of files) {
+                formData.append("file", file);
+            }
+            return formData;
+        } else {
+            return result;
+        }
     }
 
     function getChildrenByName(original, name) {
         const match = `[name="${name}"]`;
         // find the closest owning form and use this as the root element for finding matches
-        return original.closest('form').querySelectorAll(match);
+        return original.closest("form").querySelectorAll(match);
     }
 
     function isSelectMultiple(elements) {
@@ -63,26 +89,26 @@
             elements.length === 1 &&
             elements[0] instanceof HTMLSelectElement &&
             elements[0].type === "select-multiple"
-        )   
+        );
     }
 
     function parseValues(elements, includedElt, value) {
         if (!elements.length && includedElt !== undefined) {
             // "hx-include" allows CSS query selectors which may return an specific node, e.g a single input
             if (includedElt.matches(match)) {
-                elements = [includedElt]
+                elements = [includedElt];
             } else {
                 elements = includedElt.querySelectorAll(match);
             }
         }
 
         if (!Array.isArray(value)) return parseElementValue(elements[0], value);
-        
+
         if (isSelectMultiple(elements)) {
             const elt = elements[0];
             const convertToNumber = checkAllPossibleOptionsAreNumbers(elt);
             for (let index = 0; index < value.length; index++) {
-                let arrayValue = value[index]
+                let arrayValue = value[index];
                 if (convertToNumber) {
                     arrayValue = Number(arrayValue);
                 }
@@ -101,26 +127,29 @@
 
     function parseElementValue(elt, value) {
         switch (true) {
-        case elt instanceof HTMLInputElement:
-            switch (elt.type) {
-            case "checkbox":
-                return elt.checked;
-            case "number":
-            case "range": 
-                return Number(value);
-            }
-            break;
-        case elt instanceof HTMLSelectElement:
-            if (elt.type === "select-one" && checkAllPossibleOptionsAreNumbers(elt)) {
-                return Number(value);
-            }
-            break;
-        }        
+            case elt instanceof HTMLInputElement:
+                switch (elt.type) {
+                    case "checkbox":
+                        return elt.checked;
+                    case "number":
+                    case "range":
+                        return Number(value);
+                }
+                break;
+            case elt instanceof HTMLSelectElement:
+                if (
+                    elt.type === "select-one" &&
+                    checkAllPossibleOptionsAreNumbers(elt)
+                ) {
+                    return Number(value);
+                }
+                break;
+        }
         return value;
     }
 
     function checkAllPossibleOptionsAreNumbers(elt) {
-        const values = [...elt.options].map(o => o.value);
+        const values = [...elt.options].map((o) => o.value);
         if (values.length == 0) {
             return true;
         }
@@ -135,7 +164,9 @@
     function JSONEncodingPath(name) {
         let path = name;
         let original = path;
-        const FAILURE = [{ "type": "object", "key": original, "last": true, "next_type": null }];
+        const FAILURE = [
+            { type: "object", key: original, last: true, next_type: null },
+        ];
         let steps = Array();
         let first_key = String();
         for (let i = 0; i < path.length; i++) {
@@ -144,23 +175,33 @@
         }
         if (first_key === "") return FAILURE;
         path = path.slice(first_key.length);
-        steps.push({ "type": "object", "key": first_key, "last": false, "next_type": null });
+        steps.push({
+            type: "object",
+            key: first_key,
+            last: false,
+            next_type: null,
+        });
         while (path.length) {
             // []
             if (path.startsWith("[]")) {
                 path = path.slice(2);
-                steps.push({ "type": "array", "key": 0, "last": false, "next_type": null })
+                steps.push({ type: "array", key: 0, last: false, next_type: null });
                 continue;
             }
             // [123...]
             if (/^\[\d+\]/.test(path)) {
                 path = path.slice(1);
-                let collected_digits = path.match(/\d+/)[0]
+                let collected_digits = path.match(/\d+/)[0];
                 path = path.slice(collected_digits.length);
                 let numeric_key = parseInt(collected_digits, 10);
                 path = path.slice(1);
-                steps.push({ "type": "array", "key": numeric_key, "last": false, "next_type": null });
-                continue
+                steps.push({
+                    type: "array",
+                    key: numeric_key,
+                    last: false,
+                    next_type: null,
+                });
+                continue;
             }
             // [abc...]
             if (/^\[[^\]]+\]/.test(path)) {
@@ -169,7 +210,12 @@
                 path = path.slice(collected_characters.length);
                 let object_key = collected_characters;
                 path = path.slice(1);
-                steps.push({ "type": "object", "key": object_key, "last": false, "next_type": null });
+                steps.push({
+                    type: "object",
+                    key: object_key,
+                    last: false,
+                    next_type: null,
+                });
                 continue;
             }
             return FAILURE;
@@ -179,8 +225,7 @@
                 let tmp_step = steps[step_index];
                 tmp_step["last"] = true;
                 steps[step_index] = tmp_step;
-            }
-            else {
+            } else {
                 let tmp_step = steps[step_index];
                 tmp_step["next_type"] = steps[step_index + 1]["type"];
                 steps[step_index] = tmp_step;
@@ -194,7 +239,7 @@
             context[step.key] = value;
         }
 
-        //TODO: make merge functionality and file suport.
+        //TODO: make merge functionality.
 
         //check if the context value already exists
         if (context[step.key] === undefined) {
@@ -218,8 +263,7 @@
                     return context[step.key];
                 }
             }
-        }
-        else {
+        } else {
             return context[step.key];
         }
     }
@@ -229,11 +273,11 @@
 
         if (includedSelector) {
             // "hx-include" can be inherited so `elt` will not always be the root element
-            let eltWithInclude = api.getClosestMatch(elt, function(e) {
-              return e.matches(`[hx-include="${includedSelector}"]`);
-            })
+            let eltWithInclude = api.getClosestMatch(elt, function (e) {
+                return e.matches(`[hx-include="${includedSelector}"]`);
+            });
 
-            return api.querySelectorExt(eltWithInclude, includedSelector)
+            return api.querySelectorExt(eltWithInclude, includedSelector);
         }
     }
-})()
+})();

--- a/json-enc-custom.js
+++ b/json-enc-custom.js
@@ -127,21 +127,21 @@
 
     function parseElementValue(elt, value) {
         switch (true) {
-            case elt instanceof HTMLInputElement:
-                switch (elt.type) {
-                    case "checkbox":
-                        return elt.checked;
-                    case "number":
-                    case "range":
-                        return Number(value);
-                }
-                break;
-            case elt instanceof HTMLSelectElement:
-                if (elt.type === "select-one" && checkAllPossibleOptionsAreNumbers(elt)) {
-                    return Number(value);
-                }
-                break;
-        }
+        case elt instanceof HTMLInputElement:
+            switch (elt.type) {
+            case "checkbox":
+                return elt.checked;
+            case "number":
+            case "range": 
+                return Number(value);
+            }
+            break;
+        case elt instanceof HTMLSelectElement:
+            if (elt.type === "select-one" && checkAllPossibleOptionsAreNumbers(elt)) {
+                return Number(value);
+            }
+            break;
+        }        
         return value;
     }
 
@@ -255,7 +255,7 @@
 
         if (includedSelector) {
             // "hx-include" can be inherited so `elt` will not always be the root element
-            let eltWithInclude = api.getClosestMatch(elt, function (e) {
+            let eltWithInclude = api.getClosestMatch(elt, function(e) {
                 return e.matches(`[hx-include="${includedSelector}"]`);
             })
 

--- a/json-enc-custom.js
+++ b/json-enc-custom.js
@@ -1,8 +1,8 @@
 (function () {
     let api;
-    htmx.defineExtension("json-enc-custom", {
+    htmx.defineExtension('json-enc-custom', {
         init: function (apiRef) {
-            api = apiRef;
+            api = apiRef
         },
         onEvent: function (name, evt) {
             if (name === "htmx:configRequest") {
@@ -16,13 +16,13 @@
         },
         encodeParameters: function (xhr, parameters, elt) {
             if (!elt.hasAttribute("hx-multipart")) {
-                xhr.overrideMimeType("text/json");
+                xhr.overrideMimeType('text/json');
             }
 
             let encoded_parameters = encodingAlgorithm(parameters, elt);
 
             return encoded_parameters;
-        },
+        }
     });
 
     function encodingAlgorithm(parameters, elt, includedElt) {
@@ -81,7 +81,7 @@
     function getChildrenByName(original, name) {
         const match = `[name="${name}"]`;
         // find the closest owning form and use this as the root element for finding matches
-        return original.closest("form").querySelectorAll(match);
+        return original.closest('form').querySelectorAll(match);
     }
 
     function isSelectMultiple(elements) {
@@ -89,14 +89,14 @@
             elements.length === 1 &&
             elements[0] instanceof HTMLSelectElement &&
             elements[0].type === "select-multiple"
-        );
+        )
     }
 
     function parseValues(elements, includedElt, value) {
         if (!elements.length && includedElt !== undefined) {
             // "hx-include" allows CSS query selectors which may return an specific node, e.g a single input
             if (includedElt.matches(match)) {
-                elements = [includedElt];
+                elements = [includedElt]
             } else {
                 elements = includedElt.querySelectorAll(match);
             }
@@ -108,7 +108,7 @@
             const elt = elements[0];
             const convertToNumber = checkAllPossibleOptionsAreNumbers(elt);
             for (let index = 0; index < value.length; index++) {
-                let arrayValue = value[index];
+                let arrayValue = value[index]
                 if (convertToNumber) {
                     arrayValue = Number(arrayValue);
                 }
@@ -137,10 +137,7 @@
                 }
                 break;
             case elt instanceof HTMLSelectElement:
-                if (
-                    elt.type === "select-one" &&
-                    checkAllPossibleOptionsAreNumbers(elt)
-                ) {
+                if (elt.type === "select-one" && checkAllPossibleOptionsAreNumbers(elt)) {
                     return Number(value);
                 }
                 break;
@@ -149,7 +146,7 @@
     }
 
     function checkAllPossibleOptionsAreNumbers(elt) {
-        const values = [...elt.options].map((o) => o.value);
+        const values = [...elt.options].map(o => o.value);
         if (values.length == 0) {
             return true;
         }
@@ -164,9 +161,7 @@
     function JSONEncodingPath(name) {
         let path = name;
         let original = path;
-        const FAILURE = [
-            { type: "object", key: original, last: true, next_type: null },
-        ];
+        const FAILURE = [{ "type": "object", "key": original, "last": true, "next_type": null }];
         let steps = Array();
         let first_key = String();
         for (let i = 0; i < path.length; i++) {
@@ -175,33 +170,23 @@
         }
         if (first_key === "") return FAILURE;
         path = path.slice(first_key.length);
-        steps.push({
-            type: "object",
-            key: first_key,
-            last: false,
-            next_type: null,
-        });
+        steps.push({ "type": "object", "key": first_key, "last": false, "next_type": null });
         while (path.length) {
             // []
             if (path.startsWith("[]")) {
                 path = path.slice(2);
-                steps.push({ type: "array", key: 0, last: false, next_type: null });
+                steps.push({ "type": "array", "key": 0, "last": false, "next_type": null })
                 continue;
             }
             // [123...]
             if (/^\[\d+\]/.test(path)) {
                 path = path.slice(1);
-                let collected_digits = path.match(/\d+/)[0];
+                let collected_digits = path.match(/\d+/)[0]
                 path = path.slice(collected_digits.length);
                 let numeric_key = parseInt(collected_digits, 10);
                 path = path.slice(1);
-                steps.push({
-                    type: "array",
-                    key: numeric_key,
-                    last: false,
-                    next_type: null,
-                });
-                continue;
+                steps.push({ "type": "array", "key": numeric_key, "last": false, "next_type": null });
+                continue
             }
             // [abc...]
             if (/^\[[^\]]+\]/.test(path)) {
@@ -210,12 +195,7 @@
                 path = path.slice(collected_characters.length);
                 let object_key = collected_characters;
                 path = path.slice(1);
-                steps.push({
-                    type: "object",
-                    key: object_key,
-                    last: false,
-                    next_type: null,
-                });
+                steps.push({ "type": "object", "key": object_key, "last": false, "next_type": null });
                 continue;
             }
             return FAILURE;
@@ -225,7 +205,8 @@
                 let tmp_step = steps[step_index];
                 tmp_step["last"] = true;
                 steps[step_index] = tmp_step;
-            } else {
+            }
+            else {
                 let tmp_step = steps[step_index];
                 tmp_step["next_type"] = steps[step_index + 1]["type"];
                 steps[step_index] = tmp_step;
@@ -263,7 +244,8 @@
                     return context[step.key];
                 }
             }
-        } else {
+        }
+        else {
             return context[step.key];
         }
     }
@@ -275,9 +257,9 @@
             // "hx-include" can be inherited so `elt` will not always be the root element
             let eltWithInclude = api.getClosestMatch(elt, function (e) {
                 return e.matches(`[hx-include="${includedSelector}"]`);
-            });
+            })
 
-            return api.querySelectorExt(eltWithInclude, includedSelector);
+            return api.querySelectorExt(eltWithInclude, includedSelector)
         }
     }
-})();
+})()

--- a/test-env/test-env.js
+++ b/test-env/test-env.js
@@ -8,24 +8,22 @@ const waitForAllTestsToComplete = 250; // milliseconds
 let lastTestIndex = 0; // last test case index (changed when new test cases are added)
 
 function prettyJSON(jsonString) {
-    return JSON.stringify(JSON.parse(jsonString), null, 4);
+    return JSON.stringify(JSON.parse(jsonString), null, 4)
 }
 
 function addTestCase(testCaseKey, testCase, expectedResult) {
     lastTestIndex++;
     if (testCaseKey != lastTestIndex) {
-        throw new Error(
-            `Test case key doesn't match test case index: ${testCaseKey} != ${lastTestIndex}`
-        );
+        throw new Error(`Test case key doesn't match test case index: ${testCaseKey} != ${lastTestIndex}`);
     }
 
-    const testCases = document.getElementById("test-cases");
-    const newTestCase = document.createElement("tr");
+    const testCases = document.getElementById('test-cases');
+    const newTestCase = document.createElement('tr');
     newTestCase.id = `test-case-${lastTestIndex}`;
 
     newTestCase.innerHTML = `
         <th>${lastTestIndex}</th>
-        <th id=${lastTestIndex}>
+        <th>
             ${testCase}
         </th>
         <th><pre>${prettyJSON(expectedResult)}</pre></th>
@@ -33,17 +31,15 @@ function addTestCase(testCaseKey, testCase, expectedResult) {
         <th></th>
     `;
 
-    newTestCase.children[formIndex]
-        .querySelector("form")
-        .setAttribute("hx-target", `#test-case-${lastTestIndex}`);
+    newTestCase.children[formIndex].querySelector("form").setAttribute("hx-target", `#test-case-${lastTestIndex}`)
     testCases.appendChild(newTestCase);
 }
 
-// replaces default XMLHttpRequest send method so when htmx tries
-// to send a request, instead of actually sending it, browser will just
+// replaces default XMLHttpRequest send method so when htmx tries 
+// to send a request, instead of actually sending it, browser will just 
 // add a request body to the object (for using in htmx:beforeSend event listener)
 function replaceDefaultRequestSender() {
-    XMLHttpRequest.prototype.send = function (body) {
+    XMLHttpRequest.prototype.send = function(body) {
         this.capturedBody = body;
     };
 }
@@ -54,7 +50,7 @@ function replaceDefaultRequestSender() {
 function submitAllForms() {
     const testTable = document.getElementById("test-cases");
     const testCases = Array.from(testTable.children);
-    testCases.forEach(function (testCase, index) {
+    testCases.forEach(function(testCase, index) {
         const form = testCase.querySelector("tr th form");
         const inputTypeFile = form.querySelector('input[type="file"]');
         if (inputTypeFile) {
@@ -71,40 +67,29 @@ function submitAllForms() {
                 numberOfFiles
             );
         }
-
         form.requestSubmit();
-    });
+    })
 }
 
-function setActualResult(testCase, result) {
-    testCase.children[actualResultIndex].innerHTML = `<pre>${prettyJSON(
-        result
-    )}</pre>`;
-}
-
-function simulateFileUpload(
-    inputElement,
-    fileNameBase,
-    fileType,
-    numberOfFiles
-) {
+function simulateFileUpload(inputElement, fileNameBase, fileType, numberOfFiles) {
     // Create a DataTransfer to simulate the file selection
     const dataTransfer = new DataTransfer();
 
     for (let i = 0; i < numberOfFiles; i++) {
-        // Create a mock file
         const file = new File(["dummy content"], `${fileNameBase}-${i}.txt`, {
             type: fileType,
         });
         dataTransfer.items.add(file);
     }
 
-    // Assign the file list to the input element
     inputElement.files = dataTransfer.files;
 
-    // Dispatch the 'change' event to simulate user action
     const event = new Event("change", { bubbles: true });
     inputElement.dispatchEvent(event);
+}
+
+function setActualResult(testCase, result) {
+    testCase.children[actualResultIndex].innerHTML = `<pre>${prettyJSON(result)}</pre>`;
 }
 
 function checkTestResult(testCase) {
@@ -113,18 +98,15 @@ function checkTestResult(testCase) {
     const actual = testCase.children[actualResultIndex];
     const diff = testCase.children[diffIndex];
 
-    const diffContent = diffString(
-        expected.querySelector("pre").innerHTML,
-        actual.querySelector("pre").innerHTML
-    );
+    const diffContent = diffString(expected.querySelector("pre").innerHTML, actual.querySelector("pre").innerHTML);
     if (diffContent.length === 0) {
         diff.innerHTML = "✅";
         form.classList.add("pass");
-        return true;
+        return true
     } else {
         diff.innerHTML = diffContent;
         form.classList.add("fail");
-        return false;
+        return false
     }
 }
 
@@ -137,38 +119,35 @@ function diffString(expected, actual) {
     let diff = "";
     let i = 0;
     let j = 0;
-
+  
     while (i < expected.length || j < actual.length) {
-        if (i < expected.length && j < actual.length && expected[i] === actual[j]) {
-            diff += expected[i];
-            i++;
-            j++;
-        } else if (i < expected.length) {
-            diff += `<span class="diff-removed">${expected[i]}</span>`;
-            i++;
-        } else if (j < actual.length) {
-            diff += `<span class="diff-added">${actual[j]}</span>`;
-            j++;
-        }
+      if (i < expected.length && j < actual.length && expected[i] === actual[j]) {
+        diff += expected[i];
+        i++;
+        j++;
+      } else if (i < expected.length) {
+        diff += `<span class="diff-removed">${expected[i]}</span>`;
+        i++;
+      } else if (j < actual.length) {
+        diff += `<span class="diff-added">${actual[j]}</span>`;
+        j++;
+      }
     }
-
+    
     return diff;
 }
 
 function setTestResults(passed, total) {
     const results = document.getElementById("test-results");
-    results.innerHTML = `Passed ${passed}/${total} tests - ${(
-        (passed * 100) /
-        total
-    ).toFixed(2)}% success rate`;
+    results.innerHTML = `Passed ${passed}/${total} tests - ${(passed * 100 / total).toFixed(2)}% success rate`
 }
 
-window.onload = function () {
-    let passedCount = 0;
+window.onload = function() {
+    let passedCount = 0;    
 
-    document.addEventListener("htmx:beforeSend", function (evt) {
+    document.addEventListener("htmx:beforeSend", function(evt) {
         const testCase = evt.detail.target; // the hx-target in form is always set to the parent element on purpose
-        setTimeout(function () {
+        setTimeout(function() {
             if (
                 evt.detail.requestConfig.headers["Content-Type"] ===
                 "multipart/form-data"
@@ -183,17 +162,19 @@ window.onload = function () {
             } else {
                 setActualResult(testCase, evt.detail.xhr.capturedBody); // filling the Actual Result column
             }
-            passed = checkTestResult(testCase); // coloring test case and filling the Diff column
+            passed = checkTestResult(testCase); // coloring test case and filling the Diff column 
             if (passed) {
                 passedCount++;
             }
         }, waitForRequestToHappenTimeout);
-    });
+    })
 
     replaceDefaultRequestSender(); // replacing XMLHTTPRequest sender
     submitAllForms(); // submitting all forms to run the test
 
-    setTimeout(function () {
-        setTestResults(passedCount, lastTestIndex);
-    }, waitForAllTestsToComplete);
-};
+    setTimeout(
+        function() {
+            setTestResults(passedCount, lastTestIndex)
+        }, waitForAllTestsToComplete
+    );
+}

--- a/test-env/test-env.js
+++ b/test-env/test-env.js
@@ -60,12 +60,7 @@ function submitAllForms() {
             } else {
                 numberOfFiles = 1;
             }
-            simulateFileUpload(
-                inputTypeFile,
-                `test-case-${index + 1}`,
-                "text/plain",
-                numberOfFiles
-            );
+            simulateFileUpload(inputTypeFile, `test-case-${index + 1}`, "text/plain", numberOfFiles);
         }
         form.requestSubmit();
     })

--- a/test.html
+++ b/test.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <title>Tests</title>
 
@@ -10,8 +11,9 @@
     <script src="json-enc-custom.js"></script>
 
     <script src="test-env/test-env.js"></script>
-    <link rel="stylesheet" href="test-env/styles.css">
+    <link rel="stylesheet" href="test-env/styles.css" />
 </head>
+
 <body>
     <table>
         <thead>
@@ -33,8 +35,7 @@
         const testCases = {
             1: {
                 desc: "Example 1 from specification, parse-types=true",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="name" value="Bender">
                     <select name="hind">
@@ -48,12 +49,11 @@
                     "name":"Bender",
                     "hind":"Bitable",
                     "shiny":true
-                }`
+                }`,
             },
             2: {
                 desc: "Example 1 from specification, parse-types=false",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="name" value="Bender">
                     <select name="hind">
@@ -67,12 +67,11 @@
                     "name":"Bender",
                     "hind":"Bitable",
                     "shiny":"on"
-                }`
+                }`,
             },
             3: {
                 desc: "Example 2 from specification, parse-types=true",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input type="number" name="bottle-on-wall" value="1">
                     <input type="number" name="bottle-on-wall" value="2">
@@ -81,12 +80,11 @@
                 `,
                 expected: `{
                     "bottle-on-wall":[1,2,3]
-                }`
+                }`,
             },
             4: {
                 desc: "Example 2 from specification, parse-types=false",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input type="number" name="bottle-on-wall" value="1">
                     <input type="number" name="bottle-on-wall" value="2">
@@ -95,12 +93,11 @@
                 `,
                 expected: `{
                     "bottle-on-wall":["1","2","3"]
-                }`
+                }`,
             },
             5: {
                 desc: "Example 3 from specification, parse-types=true",
-                form:
-                `
+                form: `
                     <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                         <input name="pet[species]" value="Dahut">
                         <input name="pet[name]" value="Hypatia">
@@ -117,12 +114,11 @@
                         "Ashley",
                         "Thelma"
                     ]
-                }`
+                }`,
             },
             6: {
                 desc: "Example 3 from specification, parse-types=false",
-                form:
-                `
+                form: `
                     <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                         <input name="pet[species]" value="Dahut">
                         <input name="pet[name]" value="Hypatia">
@@ -139,12 +135,11 @@
                         "Ashley",
                         "Thelma"
                     ]
-                }`
+                }`,
             },
             7: {
                 desc: "Example 4 from specification, parse-types=true",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="hearbeat[0]" value="thunk">
                     <input name="hearbeat[2]" value="thunk">
@@ -152,12 +147,11 @@
                 `,
                 expected: `{
                     "hearbeat":["thunk",null,"thunk"]
-                }`
+                }`,
             },
             8: {
                 desc: "Example 4 from specification, parse-types=false",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="hearbeat[0]" value="thunk">
                     <input name="hearbeat[2]" value="thunk">
@@ -165,12 +159,11 @@
                 `,
                 expected: `{
                     "hearbeat":["thunk",null,"thunk"]
-                }`
+                }`,
             },
             9: {
                 desc: "Example 5 from specification, parse-types=true",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="pet[0][species]" value="Dahut">
                     <input name="pet[0][name]" value="Hypatia">
@@ -189,12 +182,11 @@
                             "name":"Billie"
                         }
                     ]
-                }`
+                }`,
             },
             10: {
                 desc: "Example 5 from specification, parse-types=false",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="pet[0][species]" value="Dahut">
                     <input name="pet[0][name]" value="Hypatia">
@@ -213,12 +205,11 @@
                             "name":"Billie"
                         }
                     ]
-                }`
+                }`,
             },
             11: {
                 desc: "Example 6 from specification, parse-types=true",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="wow[such][deep][3][much][power][!]" value="Amaze">
                 </form>
@@ -240,12 +231,11 @@
                             ]
                         }
                     }
-                }`
+                }`,
             },
             12: {
                 desc: "Example 6 from specification, parse-types=false",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="wow[such][deep][3][much][power][!]" value="Amaze">
                 </form>
@@ -267,12 +257,11 @@
                             ]
                         }
                     }
-                }`
+                }`,
             },
             13: {
                 desc: "Example 7 from specification, parse-types=true",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="mix" value="scalar">
                     <input name="mix[0]" value="array 1">
@@ -288,13 +277,12 @@
                         "2":"array 2",
                         "key":"key key",
                         "car":"car key"}
-                    }`
+                    }`,
             },
             14: {
                 desc: "Example 7 from specification, parse-types=false",
-                form:
-                `
-                <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
+                form: `
+                <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="mix" value="scalar">
                     <input name="mix[0]" value="array 1">
                     <input name="mix[2]" value="array 2">
@@ -310,38 +298,35 @@
                         "key":"key key",
                         "car":"car key"
                     }
-                }`
+                }`,
             },
             15: {
                 desc: "Example 8 from specification, parse-types=true",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="highlander[]" value="one">
                 </form>
                 `,
                 expected: `{
                     "highlander":["one"]
-                }`
+                }`,
             },
             16: {
                 desc: "Example 8 from specification, parse-types=false",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="highlander[]" value="one">
                 </form>
                 `,
                 expected: `{
                     "highlander":["one"]
-                }`
+                }`,
             },
             // Example 9 is not included because it contains a file input
             // may be included in later version (but now it makes no sense)
             17: {
                 desc: "Example 10 from specification, parse-types=true",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="error[good]" value="BOOM!">
                     <input name="error[bad" value="BOOM BOOM!">
@@ -350,12 +335,11 @@
                 expected: `{
                     "error":{"good":"BOOM!"},
                     "error[bad":"BOOM BOOM!"
-                }`
+                }`,
             },
             18: {
                 desc: "Example 10 from specification, parse-types=false",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="error[good]" value="BOOM!">
                     <input name="error[bad" value="BOOM BOOM!">
@@ -364,12 +348,11 @@
                 expected: `{
                     "error":{"good":"BOOM!"},
                     "error[bad":"BOOM BOOM!"
-                }`
+                }`,
             },
             19: {
                 desc: "All possible tags in form, parse-types=true",
-                form:
-                `
+                form: `
                 <form 
                     hx-ext="json-enc-custom" 
                     hx-post="/" 
@@ -420,12 +403,11 @@
                     "select-one-numbers":3.14,
                     "select-multiple-combined":["multiple-2","3"],
                     "select-multiple-numbers":[1,2]
-                }`
+                }`,
             },
             20: {
                 desc: "All possible tags in form, parse-types=false",
-                form:
-                `
+                form: `
                 <form 
                     hx-ext="json-enc-custom" 
                     hx-post="/" 
@@ -476,12 +458,11 @@
                     "select-one-numbers":"3.14",
                     "select-multiple-combined":["multiple-2","3"],
                     "select-multiple-numbers":["1","2"]
-                }`
+                }`,
             },
             21: {
                 desc: "select[multiple] with only one option selected",
-                form:
-                `
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <select name="select" multiple> 
                         <option value="1" selected>First</option>
@@ -492,12 +473,11 @@
                 `,
                 expected: `{
                     "select": ["1"]
-                }`
+                }`,
             },
             22: {
-                desc: "name is equal to \"values\"",
-                form:
-                `
+                desc: 'name is equal to "values"',
+                form: `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input type="text" name="values" value="abc"></input>
                     <input type="text" name="value"  value="abc"></input>
@@ -506,14 +486,40 @@
                 expected: `{
                     "values": "abc",
                     "value": "abc"
-                }`
+                }`,
+            },
+            23: {
+                desc: "multipart support",
+                form: `
+                <form hx-ext="json-enc-custom" hx-post="/" hx-multipart parse-types="false">
+                    <input type="file" name="sampleFile"></input>
+                    <input type="text" name="value"  value="abc"></input>
+                </form>
+                `,
+                expected: `{
+                    "data": { "value": "abc" },
+                    "files": ["test-case-23-0.txt"]
+                }`,
+            },
+            24: {
+                desc: "multipart support with multiple files",
+                form: `
+                <form hx-ext="json-enc-custom" hx-post="/" hx-multipart parse-types="false">
+                    <input type="file" name="sampleFile" multiple></input>
+                    <input type="text" name="value"  value="abc"></input>
+                </form>
+                `,
+                expected: `{
+                    "data": { "value": "abc" },
+                    "files": ["test-case-24-0.txt", "test-case-24-1.txt"]
+                }`,
             },
         };
 
         const urlParams = new URLSearchParams(window.location.search);
         const isolateTestKey = urlParams.get("isolate-test");
 
-        Object.keys(testCases).forEach(function(testCaseKey) {
+        Object.keys(testCases).forEach(function (testCaseKey) {
             const testCase = testCases[testCaseKey];
             if (isolateTestKey !== null) {
                 if (testCaseKey == isolateTestKey) {
@@ -526,4 +532,5 @@
         });
     </script>
 </body>
+
 </html>

--- a/test.html
+++ b/test.html
@@ -1,9 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <title>Tests</title>
 
@@ -11,9 +10,8 @@
     <script src="json-enc-custom.js"></script>
 
     <script src="test-env/test-env.js"></script>
-    <link rel="stylesheet" href="test-env/styles.css" />
+    <link rel="stylesheet" href="test-env/styles.css">
 </head>
-
 <body>
     <table>
         <thead>
@@ -35,7 +33,8 @@
         const testCases = {
             1: {
                 desc: "Example 1 from specification, parse-types=true",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="name" value="Bender">
                     <select name="hind">
@@ -49,11 +48,12 @@
                     "name":"Bender",
                     "hind":"Bitable",
                     "shiny":true
-                }`,
+                }`
             },
             2: {
                 desc: "Example 1 from specification, parse-types=false",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="name" value="Bender">
                     <select name="hind">
@@ -67,11 +67,12 @@
                     "name":"Bender",
                     "hind":"Bitable",
                     "shiny":"on"
-                }`,
+                }`
             },
             3: {
                 desc: "Example 2 from specification, parse-types=true",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input type="number" name="bottle-on-wall" value="1">
                     <input type="number" name="bottle-on-wall" value="2">
@@ -80,11 +81,12 @@
                 `,
                 expected: `{
                     "bottle-on-wall":[1,2,3]
-                }`,
+                }`
             },
             4: {
                 desc: "Example 2 from specification, parse-types=false",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input type="number" name="bottle-on-wall" value="1">
                     <input type="number" name="bottle-on-wall" value="2">
@@ -93,11 +95,12 @@
                 `,
                 expected: `{
                     "bottle-on-wall":["1","2","3"]
-                }`,
+                }`
             },
             5: {
                 desc: "Example 3 from specification, parse-types=true",
-                form: `
+                form:
+                `
                     <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                         <input name="pet[species]" value="Dahut">
                         <input name="pet[name]" value="Hypatia">
@@ -114,11 +117,12 @@
                         "Ashley",
                         "Thelma"
                     ]
-                }`,
+                }`
             },
             6: {
                 desc: "Example 3 from specification, parse-types=false",
-                form: `
+                form:
+                `
                     <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                         <input name="pet[species]" value="Dahut">
                         <input name="pet[name]" value="Hypatia">
@@ -135,11 +139,12 @@
                         "Ashley",
                         "Thelma"
                     ]
-                }`,
+                }`
             },
             7: {
                 desc: "Example 4 from specification, parse-types=true",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="hearbeat[0]" value="thunk">
                     <input name="hearbeat[2]" value="thunk">
@@ -147,11 +152,12 @@
                 `,
                 expected: `{
                     "hearbeat":["thunk",null,"thunk"]
-                }`,
+                }`
             },
             8: {
                 desc: "Example 4 from specification, parse-types=false",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="hearbeat[0]" value="thunk">
                     <input name="hearbeat[2]" value="thunk">
@@ -159,11 +165,12 @@
                 `,
                 expected: `{
                     "hearbeat":["thunk",null,"thunk"]
-                }`,
+                }`
             },
             9: {
                 desc: "Example 5 from specification, parse-types=true",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="pet[0][species]" value="Dahut">
                     <input name="pet[0][name]" value="Hypatia">
@@ -182,11 +189,12 @@
                             "name":"Billie"
                         }
                     ]
-                }`,
+                }`
             },
             10: {
                 desc: "Example 5 from specification, parse-types=false",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="pet[0][species]" value="Dahut">
                     <input name="pet[0][name]" value="Hypatia">
@@ -205,11 +213,12 @@
                             "name":"Billie"
                         }
                     ]
-                }`,
+                }`
             },
             11: {
                 desc: "Example 6 from specification, parse-types=true",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="wow[such][deep][3][much][power][!]" value="Amaze">
                 </form>
@@ -231,11 +240,12 @@
                             ]
                         }
                     }
-                }`,
+                }`
             },
             12: {
                 desc: "Example 6 from specification, parse-types=false",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="wow[such][deep][3][much][power][!]" value="Amaze">
                 </form>
@@ -257,11 +267,12 @@
                             ]
                         }
                     }
-                }`,
+                }`
             },
             13: {
                 desc: "Example 7 from specification, parse-types=true",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="mix" value="scalar">
                     <input name="mix[0]" value="array 1">
@@ -277,11 +288,12 @@
                         "2":"array 2",
                         "key":"key key",
                         "car":"car key"}
-                    }`,
+                    }`
             },
             14: {
                 desc: "Example 7 from specification, parse-types=false",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="mix" value="scalar">
                     <input name="mix[0]" value="array 1">
@@ -298,35 +310,38 @@
                         "key":"key key",
                         "car":"car key"
                     }
-                }`,
+                }`
             },
             15: {
                 desc: "Example 8 from specification, parse-types=true",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="highlander[]" value="one">
                 </form>
                 `,
                 expected: `{
                     "highlander":["one"]
-                }`,
+                }`
             },
             16: {
                 desc: "Example 8 from specification, parse-types=false",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="highlander[]" value="one">
                 </form>
                 `,
                 expected: `{
                     "highlander":["one"]
-                }`,
+                }`
             },
             // Example 9 is not included because it contains a file input
             // may be included in later version (but now it makes no sense)
             17: {
                 desc: "Example 10 from specification, parse-types=true",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="true">
                     <input name="error[good]" value="BOOM!">
                     <input name="error[bad" value="BOOM BOOM!">
@@ -335,11 +350,12 @@
                 expected: `{
                     "error":{"good":"BOOM!"},
                     "error[bad":"BOOM BOOM!"
-                }`,
+                }`
             },
             18: {
                 desc: "Example 10 from specification, parse-types=false",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input name="error[good]" value="BOOM!">
                     <input name="error[bad" value="BOOM BOOM!">
@@ -348,11 +364,12 @@
                 expected: `{
                     "error":{"good":"BOOM!"},
                     "error[bad":"BOOM BOOM!"
-                }`,
+                }`
             },
             19: {
                 desc: "All possible tags in form, parse-types=true",
-                form: `
+                form:
+                `
                 <form 
                     hx-ext="json-enc-custom" 
                     hx-post="/" 
@@ -403,11 +420,12 @@
                     "select-one-numbers":3.14,
                     "select-multiple-combined":["multiple-2","3"],
                     "select-multiple-numbers":[1,2]
-                }`,
+                }`
             },
             20: {
                 desc: "All possible tags in form, parse-types=false",
-                form: `
+                form:
+                `
                 <form 
                     hx-ext="json-enc-custom" 
                     hx-post="/" 
@@ -458,11 +476,12 @@
                     "select-one-numbers":"3.14",
                     "select-multiple-combined":["multiple-2","3"],
                     "select-multiple-numbers":["1","2"]
-                }`,
+                }`
             },
             21: {
                 desc: "select[multiple] with only one option selected",
-                form: `
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <select name="select" multiple> 
                         <option value="1" selected>First</option>
@@ -473,11 +492,12 @@
                 `,
                 expected: `{
                     "select": ["1"]
-                }`,
+                }`
             },
             22: {
-                desc: 'name is equal to "values"',
-                form: `
+                desc: "name is equal to \"values\"",
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" parse-types="false">
                     <input type="text" name="values" value="abc"></input>
                     <input type="text" name="value"  value="abc"></input>
@@ -486,11 +506,12 @@
                 expected: `{
                     "values": "abc",
                     "value": "abc"
-                }`,
+                }`
             },
             23: {
-                desc: "multipart support",
-                form: `
+                desc: "multipart/form-data single file",
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" hx-multipart parse-types="false">
                     <input type="file" name="sampleFile"></input>
                     <input type="text" name="value"  value="abc"></input>
@@ -499,11 +520,12 @@
                 expected: `{
                     "data": { "value": "abc" },
                     "files": ["test-case-23-0.txt"]
-                }`,
+                }`
             },
             24: {
-                desc: "multipart support with multiple files",
-                form: `
+                desc: "multipart/form-data multiple files",
+                form:
+                `
                 <form hx-ext="json-enc-custom" hx-post="/" hx-multipart parse-types="false">
                     <input type="file" name="sampleFile" multiple></input>
                     <input type="text" name="value"  value="abc"></input>
@@ -512,14 +534,14 @@
                 expected: `{
                     "data": { "value": "abc" },
                     "files": ["test-case-24-0.txt", "test-case-24-1.txt"]
-                }`,
+                }`
             },
         };
 
         const urlParams = new URLSearchParams(window.location.search);
         const isolateTestKey = urlParams.get("isolate-test");
 
-        Object.keys(testCases).forEach(function (testCaseKey) {
+        Object.keys(testCases).forEach(function(testCaseKey) {
             const testCase = testCases[testCaseKey];
             if (isolateTestKey !== null) {
                 if (testCaseKey == isolateTestKey) {
@@ -532,5 +554,4 @@
         });
     </script>
 </body>
-
 </html>


### PR DESCRIPTION
Heyyy, so recently I had a requirement to send files using this amazing plugin. Initially, I added support for `multipart/form-data` in our company's version of this plugin but considering we didn't have any issues after months of use, I decided to create this PR since adding file support `TODO` still existed 😅

- The way it works is that if the `hx-multipart` attribute is passed, then instead of encoding parameters in `text/json`, it gets encoded into `multipart/form-data`.
- This enables support for uploading file(s) as it requires the form to be `multipart`.
- Despite the mime-type being multipart, the parameters that are not an `instanceof File` are encoded as if it's normal JSON data.
- The only quirk of this implementation is that multipart data will always be encoded in the following format: `{ 'data': <parameters that are not File in JSON type>, 'file': <files data>  }`.
- Add tests in the `test.html` file for `multipart/form-data`.

~**PS:** My editor has auto-format with 'Prettier' setup, and hence one might see some formatting changes like changing from `'` -> `"`, so sorry in advance.~